### PR TITLE
godon api release correct image name

### DIFF
--- a/.github/workflows/godon-api-release.yml
+++ b/.github/workflows/godon-api-release.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: godon-api
+  IMAGE_NAME: cherusk/godon-api
 
 jobs:
   build-and-release-image:


### PR DESCRIPTION
Has to include parent prefix. Please see ghcr.io
naming convetions.