### PR TITLE
godon prometheus internas exporter repair runnability

### DIFF
--- a/godon-metrics-exporter/Dockerfile
+++ b/godon-metrics-exporter/Dockerfile
@@ -9,6 +9,9 @@ ENV EXPORTER_DIR="/user/local/godon_exporter/"
 RUN nimble install metrics && \
     nimble install db_connector
 
+RUN apt update && apt install -y libpq5 && \\
+    apt-get clean
+
 # Place nim code
 COPY ./*.nim "${EXPORTER_DIR}"
 

--- a/godon-metrics-exporter/exporter.nim
+++ b/godon-metrics-exporter/exporter.nim
@@ -69,4 +69,9 @@ var args = parse_args()
 
 echo "port - $1" % [ args["port"] ]
 
-startMetricsHttpServer("127.0.0.1", Port(parseInt(args["port"])))
+chronos_httpserver.startMetricsHttpServer("127.0.0.1", Port(parseInt(args["port"])))
+
+## Todo: improve the loop in the main thread with something
+## more threading native
+while true:
+  sleep(10000)


### PR DESCRIPTION
So far, the main thread exited plus the clone thread.

Now we have simplistic way of looping in the main for now to keep the server thread open.

Also solves dependency on postgres library for clienting with godon meta state.