### PR TITLE
fix OpenAPI spec response examples wrapping

### DIFF
--- a/images/godon-api/openapi.yml
+++ b/images/godon-api/openapi.yml
@@ -64,14 +64,15 @@ paths:
                 breeders:
                   summary: Example list of breeders
                   value:
-                    - id: "550e8400-e29b-41d4-a716-446655440000"
-                      name: "genetic-optimizer-1"
-                      status: "active"
-                      createdAt: "2024-01-15T10:30:00Z"
-                    - id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
-                      name: "neural-breeder-2"
-                      status: "paused"
-                      createdAt: "2024-01-16T14:20:00Z"
+                    breeders:
+                      - id: "550e8400-e29b-41d4-a716-446655440000"
+                        name: "genetic-optimizer-1"
+                        status: "active"
+                        createdAt: "2024-01-15T10:30:00Z"
+                      - id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+                        name: "neural-breeder-2"
+                        status: "paused"
+                        createdAt: "2024-01-16T14:20:00Z"
         '500':
           $ref: '#/components/responses/InternalServerError'
 


### PR DESCRIPTION
  - Fix example response structure to match schema definitions
  - Wrap breeders/credentials list examples in proper object format
  - Ensure Prism returns structured responses matching API contract
  - Fix credential list parsing in CLI by correcting response format
  - Update breeders list examples for consistency