### PR TITLE
godon-api - hash-based wmill script exec for reliability

### DIFF
--- a/.github/workflows/godon-seeder-ci.yml
+++ b/.github/workflows/godon-seeder-ci.yml
@@ -115,9 +115,9 @@ jobs:
           -e WINDMILL_EMAIL=admin@test.com \
           -e WINDMILL_PASSWORD=test123 \
           -e CONTROLLER_REPO=https://github.com/godon-dev/godon-controller.git \
-          -e CONTROLLER_VERSION=0.1.0 \
+          -e CONTROLLER_VERSION=0.3.0 \
           -e BREEDER_REPO=https://github.com/godon-dev/godon-breeders.git \
-          -e BREEDER_VERSION=0.1.0 \
+          -e BREEDER_VERSION=0.7.0 \
           -e GODON_DIR=/var/lib/godon \
           -e SEEDER_MAX_RETRIES=5 \
           -e SEEDER_RETRY_DELAY=2 \

--- a/images/godon-api/src/godon_windmill_adapter.nim
+++ b/images/godon-api/src/godon_windmill_adapter.nim
@@ -89,6 +89,7 @@ proc newWindmillClient*(godonCfg: Config): WindmillApiClient =
     windmillBaseUrl: godonCfg.windmillBaseUrl,
     windmillApiBaseUrl: godonCfg.windmillApiBaseUrl,
     windmillWorkspace: godonCfg.windmillWorkspace,
+    windmillFolder: godonCfg.windmillFolder,
     windmillEmail: "admin@windmill.dev",
     windmillPassword: "changeme",
     maxRetries: 3,  # API should fail fast rather than retry for extended periods

--- a/images/godon-api/tests/express-proxy/proxy.js
+++ b/images/godon-api/tests/express-proxy/proxy.js
@@ -20,7 +20,117 @@ app.use((req, res, next) => {
 
 // Mock responses for specific flow paths (decoded URLs)
 const mockResponses = {
-  '/w/godon/jobs/run_wait_result/p/f/controller/breeders_get': {
+  // Script GET endpoints - return hash for hash-based execution
+  '/w/godon/scripts/get/p/f/controller/breeders_get': {
+    workspace_id: "godon",
+    hash: "7060bc7c7f578a1a",
+    path: "f/controller/breeders_get",
+    summary: "Godon Controller API",
+    description: "Controller logic for managing Godon breeder lifecycles",
+    created_by: "admin",
+    created_at: "2024-01-15T10:30:00Z",
+    archived: false,
+    language: "python3",
+    kind: "script"
+  },
+  '/w/godon/scripts/get/p/f/controller/breeder_create': {
+    workspace_id: "godon",
+    hash: "abc123def456",
+    path: "f/controller/breeder_create",
+    summary: "Create Breeder",
+    description: "Create a new breeder",
+    created_by: "admin",
+    created_at: "2024-01-15T10:30:00Z",
+    archived: false,
+    language: "python3",
+    kind: "script"
+  },
+  '/w/godon/scripts/get/p/f/controller/breeder_delete': {
+    workspace_id: "godon",
+    hash: "def789ghi012",
+    path: "f/controller/breeder_delete",
+    summary: "Delete Breeder",
+    description: "Delete a breeder",
+    created_by: "admin",
+    created_at: "2024-01-15T10:30:00Z",
+    archived: false,
+    language: "python3",
+    kind: "script"
+  },
+  '/w/godon/scripts/get/p/f/controller/breeder_update': {
+    workspace_id: "godon",
+    hash: "ghi345jkl345",
+    path: "f/controller/breeder_update",
+    summary: "Update Breeder",
+    description: "Update a breeder",
+    created_by: "admin",
+    created_at: "2024-01-15T10:30:00Z",
+    archived: false,
+    language: "python3",
+    kind: "script"
+  },
+  '/w/godon/scripts/get/p/f/controller/breeder_get': {
+    workspace_id: "godon",
+    hash: "jkl567mno678",
+    path: "f/controller/breeder_get",
+    summary: "Get Breeder",
+    description: "Get a specific breeder",
+    created_by: "admin",
+    created_at: "2024-01-15T10:30:00Z",
+    archived: false,
+    language: "python3",
+    kind: "script"
+  },
+  '/w/godon/scripts/get/p/f/controller/credentials_get': {
+    workspace_id: "godon",
+    hash: "pqr890stu789",
+    path: "f/controller/credentials_get",
+    summary: "List Credentials",
+    description: "List all credentials",
+    created_by: "admin",
+    created_at: "2024-01-15T10:30:00Z",
+    archived: false,
+    language: "python3",
+    kind: "script"
+  },
+  '/w/godon/scripts/get/p/f/controller/credential_create': {
+    workspace_id: "godon",
+    hash: "stu901vwx890",
+    path: "f/controller/credential_create",
+    summary: "Create Credential",
+    description: "Create a new credential",
+    created_by: "admin",
+    created_at: "2024-01-15T10:30:00Z",
+    archived: false,
+    language: "python3",
+    kind: "script"
+  },
+  '/w/godon/scripts/get/p/f/controller/credential_get': {
+    workspace_id: "godon",
+    hash: "vwx012yzab12",
+    path: "f/controller/credential_get",
+    summary: "Get Credential",
+    description: "Get a specific credential",
+    created_by: "admin",
+    created_at: "2024-01-15T10:30:00Z",
+    archived: false,
+    language: "python3",
+    kind: "script"
+  },
+  '/w/godon/scripts/get/p/f/controller/credential_delete': {
+    workspace_id: "godon",
+    hash: "zab345cde34",
+    path: "f/controller/credential_delete",
+    summary: "Delete Credential",
+    description: "Delete a credential",
+    created_by: "admin",
+    created_at: "2024-01-15T10:30:00Z",
+    archived: false,
+    language: "python3",
+    kind: "script"
+  },
+  // Hash-based execution endpoints (new flow - same responses as old path-based)
+  '/w/godon/jobs/run_wait_result/h/7060bc7c7f578a1a': {
     breeders: [
       {
         id: "550e8400-e29b-41d4-a716-446655440010",
@@ -44,16 +154,16 @@ const mockResponses = {
       }
     ]
   },
-  '/w/godon/jobs/run_wait_result/p/f/controller/breeder_create': {
+  '/w/godon/jobs/run_wait_result/h/abc123def456': {
     id: "550e8400-e29b-41d4-a716-446655440010",
     name: "test_breeder",
     status: "active",
     createdAt: "2024-01-15T10:30:00Z"
   },
-  '/w/godon/jobs/run_wait_result/p/f/controller/breeder_delete': {
+  '/w/godon/jobs/run_wait_result/h/def789ghi012': {
     success: true
   },
-  '/w/godon/jobs/run_wait_result/p/f/controller/breeder_update': {
+  '/w/godon/jobs/run_wait_result/h/ghi345jkl345': {
     id: "550e8400-e29b-41d4-a716-446655440010",
     name: "updated-genetic-optimizer",
     status: "active",
@@ -63,7 +173,7 @@ const mockResponses = {
       setting2: 200
     }
   },
-  '/w/godon/jobs/run_wait_result/p/f/controller/breeder_get': {
+  '/w/godon/jobs/run_wait_result/h/jkl567mno678': {
     id: "550e8400-e29b-41d4-a716-446655440010",
     name: "genetic-optimizer-test",
     status: "active",
@@ -73,13 +183,13 @@ const mockResponses = {
       max_iterations: 100
     }
   },
-  '/w/godon/jobs/run_wait_result/p/f/controller/credentials_get': [
+  '/w/godon/jobs/run_wait_result/h/pqr890stu789': [
     {
       id: "550e8400-e29b-41d4-a716-446655440011",
       name: "production_ssh_key",
       credentialType: "ssh_private_key",
       description: "SSH key for production servers",
-        windmillVariable: "f/vars/prod_ssh_key",
+      windmillVariable: "f/vars/prod_ssh_key",
       createdAt: "2024-01-15T10:30:00Z",
       lastUsedAt: "2024-01-16T14:20:00Z"
     },
@@ -93,7 +203,7 @@ const mockResponses = {
       lastUsedAt: null
     }
   ],
-  '/w/godon/jobs/run_wait_result/p/f/controller/credential_create': {
+  '/w/godon/jobs/run_wait_result/h/stu901vwx890': {
     id: "550e8400-e29b-41d4-a716-446655440002",
     name: "test_ssh_key",
     credentialType: "ssh_private_key",
@@ -101,7 +211,7 @@ const mockResponses = {
     windmillVariable: "f/vars/test_ssh_key",
     createdAt: "2024-01-17T12:00:00Z"
   },
-  '/w/godon/jobs/run_wait_result/p/f/controller/credential_get': {
+  '/w/godon/jobs/run_wait_result/h/vwx012yzab12': {
     id: "550e8400-e29b-41d4-a716-446655440011",
     name: "production_ssh_key",
     credentialType: "ssh_private_key",
@@ -111,7 +221,7 @@ const mockResponses = {
     lastUsedAt: "2024-01-16T14:20:00Z",
     content: "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA2Z9Q...\n-----END RSA PRIVATE KEY-----"
   },
-  '/w/godon/jobs/run_wait_result/p/f/controller/credential_delete': {
+  '/w/godon/jobs/run_wait_result/h/zab345cde34': {
     result: "SUCCESS",
     message: "Credential 'production_ssh_key' (ID: 550e8400-e29b-41d4-a716-446655440011) successfully deleted"
   }

--- a/images/godon-seeder/godon_seeder.nim
+++ b/images/godon-seeder/godon_seeder.nim
@@ -359,6 +359,7 @@ proc seedWorkspace*(config: SeederConfig) =
     windmillBaseUrl: config.windmillBaseUrl,
     windmillApiBaseUrl: "",
     windmillWorkspace: config.windmillWorkspace,
+    windmillFolder: "",  # Not needed for seeder - only deploys, doesn't execute
     windmillEmail: config.windmillEmail,
     windmillPassword: config.windmillPassword,
     maxRetries: config.maxRetries,

--- a/shared/windmill_client/config.nim
+++ b/shared/windmill_client/config.nim
@@ -7,7 +7,7 @@ type
     windmillBaseUrl*: string
     windmillApiBaseUrl*: string
     windmillWorkspace*: string
-    windmillFolder*: string
+    windmillFolder*: string  # Optional: only needed for hash-based execution
     windmillEmail*: string
     windmillPassword*: string
     maxRetries*: int

--- a/shared/windmill_client/config.nim
+++ b/shared/windmill_client/config.nim
@@ -7,6 +7,7 @@ type
     windmillBaseUrl*: string
     windmillApiBaseUrl*: string
     windmillWorkspace*: string
+    windmillFolder*: string
     windmillEmail*: string
     windmillPassword*: string
     maxRetries*: int
@@ -36,6 +37,7 @@ proc loadWindmillConfig*(): WindmillConfig =
     result.windmillBaseUrl = "http://" & host & ":" & port
   
   result.windmillWorkspace = getEnv("WINDMILL_WORKSPACE", "godon")
+  result.windmillFolder = getEnv("WINDMILL_FOLDER", "controller")
   result.windmillEmail = getEnv("WINDMILL_EMAIL", "admin@windmill.dev")
   result.windmillPassword = getEnv("WINDMILL_PASSWORD", "changeme")
   result.maxRetries = parseInt(getEnv("WINDMILL_MAX_RETRIES", "30"))


### PR DESCRIPTION
This change addresses a nissue where scripts created via API that require lock generation are not automatically deployed, making them unrunnable by path.

Root cause: When scripts require lock generation (needs_lock_gen == true), the deployment_metadata record is never created, causing path-based execution to fail with "deployed script not found at name".

Solution: Implemented hash-based execution as the primary mechanism:
- Lookup script by path to get hash
- Run job by hash instead of path
- Include X-Godon-Script-Path header for tracing

Changes:
1. windmill_client.nim:
- Added getScriptByPath() to retrieve script metadata and hash
- Added runJobByHash() to execute by hash with tracing header
- Refactored runJob() to use hash-based execution

2. config.nim:
- Added windmillFolder field to WindmillConfig type
- Loaded from WINDMILL_FOLDER env var (defaults to "controller")

3. godon_windmill_adapter.nim:
- Pass windmillFolder from godon config to shared WindmillConfig

4. tests/express-proxy/proxy.js:
- Added GET /scripts/get/p/{path} mock endpoints returning hashes
- Replaced path-based execution mocks with hash-based execution mocks
- All script operations now use hash-based flow

 This approach is more robust and works regardless of deployment status.
 Tracing header helps debug issues even when Windmill ignores it.

Co-Authored-By: godon_robot (GLM 4.7)