### PR TITLE
Feat: Add breeder lifecycle management endpoints

### DIFF
--- a/.github/workflows/godon-api-ci.yml
+++ b/.github/workflows/godon-api-ci.yml
@@ -214,12 +214,33 @@ jobs:
           breeder update --file=/update-config.yaml \
           || echo "✅ Update correctly returned NOT_IMPLEMENTED as expected"
 
-        # Test deleting a breeder
-        echo "Testing delete breeder:"
+        # Test deleting a breeder (safe mode without workers)
+        echo "Testing delete breeder (safe mode):"
         docker run --rm --network godon-api-test_default \
           ${{ steps.cli-image.outputs.CLI_CONTAINER_IMAGE }} \
           --hostname=godon-api-test --port=9090 --insecure \
           breeder purge --id=550e8400-e29b-41d4-a716-446655440000
+
+        # Test stop breeder
+        echo "Testing stop breeder:"
+        docker run --rm --network godon-api-test_default \
+          ${{ steps.cli-image.outputs.CLI_CONTAINER_IMAGE }} \
+          --hostname=godon-api-test --port=9090 --insecure \
+          breeder stop --id=550e8400-e29b-41d4-a716-446655440000
+
+        # Test start breeder
+        echo "Testing start breeder:"
+        docker run --rm --network godon-api-test_default \
+          ${{ steps.cli-image.outputs.CLI_CONTAINER_IMAGE }} \
+          --hostname=godon-api-test --port=9090 --insecure \
+          breeder start --id=550e8400-e29b-41d4-a716-446655440000
+
+        # Test force delete breeder
+        echo "Testing force delete breeder:"
+        docker run --rm --network godon-api-test_default \
+          ${{ steps.cli-image.outputs.CLI_CONTAINER_IMAGE }} \
+          --hostname=godon-api-test --port=9090 --insecure \
+          breeder purge --force --id=550e8400-e29b-41d4-a716-446655440000
 
         # Test error scenarios
         echo "Testing error scenarios..."

--- a/images/godon-api/openapi.yml
+++ b/images/godon-api/openapi.yml
@@ -202,7 +202,25 @@ paths:
         - breeders
       operationId: deleteBreeder
       summary: Delete a breeder
-      description: Permanently removes a breeder and its configuration
+      description: |
+        Permanently removes a breeder and its configuration.
+
+        **Default behavior (safe):** Requires workers to be gracefully stopped first.
+        Call `stop_breeder()` to request graceful shutdown, then delete.
+
+        **Force deletion:** Use `force=true` to cancel workers immediately.
+        Use for automated cleanup or when worker state is not important.
+      parameters:
+        - name: force
+          in: query
+          description: |
+            Cancel workers immediately instead of requiring graceful stop.
+            Default is false (safe).
+          required: false
+          schema:
+            type: boolean
+            default: false
+          example: true
       responses:
         '200':
           description: Successfully deleted the breeder
@@ -227,6 +245,122 @@ paths:
                   value:
                     id: "550e8400-e29b-41d4-a716-446655440000"
                     deleted: true
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /breeders/{breederId}/stop:
+    post:
+      tags:
+        - breeders
+      operationId: stopBreeder
+      summary: Stop a breeder
+      description: |
+        Requests graceful shutdown of a breeder's workers.
+        Workers will finish their current trial before stopping.
+        This is an asynchronous operation - check status with GET /breeders/{breederId}.
+      parameters:
+        - $ref: '#/components/parameters/BreederId'
+      responses:
+        '200':
+          description: Graceful shutdown requested successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - result
+                  - data
+                properties:
+                  result:
+                    type: string
+                    enum: [SUCCESS]
+                  data:
+                    type: object
+                    required:
+                      - breeder_id
+                      - shutdown_type
+                    properties:
+                      breeder_id:
+                        type: string
+                        format: uuid
+                        description: The ID of the breeder to stop
+                      shutdown_type:
+                        type: string
+                        enum: [graceful]
+                        description: Type of shutdown (graceful)
+              examples:
+                shutdownRequested:
+                  summary: Graceful shutdown requested
+                  value:
+                    result: "SUCCESS"
+                    message: "Graceful shutdown requested. Workers will stop after completing current trials."
+                    data:
+                      breeder_id: "550e8400-e29b-41d4-a716-446655440000"
+                      shutdown_type: "graceful"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /breeders/{breederId}/start:
+    post:
+      tags:
+        - breeders
+      operationId: startBreeder
+      summary: Start/resume a breeder
+      description: |
+        Starts or resumes a stopped breeder by clearing the shutdown flag
+        and relaunching workers. Use this to resume optimization after
+        calling stop_breeder().
+      parameters:
+        - $ref: '#/components/parameters/BreederId'
+      responses:
+        '200':
+          description: Breeder started successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - result
+                  - data
+                properties:
+                  result:
+                    type: string
+                    enum: [SUCCESS]
+                  data:
+                    type: object
+                    required:
+                      - breeder_id
+                      - status
+                      - workers_started
+                    properties:
+                      breeder_id:
+                        type: string
+                        format: uuid
+                        description: The ID of the breeder that was started
+                      status:
+                        type: string
+                        enum: [ACTIVE]
+                        description: New status of the breeder
+                      workers_started:
+                        type: integer
+                        description: Number of worker jobs that were launched
+              examples:
+                started:
+                  summary: Breeder started successfully
+                  value:
+                    result: "SUCCESS"
+                    data:
+                      breeder_id: "550e8400-e29b-41d4-a716-446655440000"
+                      workers_started: 3
+                      status: "ACTIVE"
         '400':
           $ref: '#/components/responses/BadRequest'
         '404':

--- a/images/godon-api/src/godon_api.nim
+++ b/images/godon-api/src/godon_api.nim
@@ -77,7 +77,27 @@ routes:
   delete "/breeders/@id":
     let (code, response) = handleBreederDelete(request, @"id")
     resp code, [(
-      key: "Content-Type", 
+      key: "Content-Type",
+      val: "application/json"
+    ), (
+      key: "Access-Control-Allow-Origin",
+      val: "*"
+    )], response
+
+  post "/breeders/@id/stop":
+    let (code, response) = handleBreederStop(request, @"id")
+    resp code, [(
+      key: "Content-Type",
+      val: "application/json"
+    ), (
+      key: "Access-Control-Allow-Origin",
+      val: "*"
+    )], response
+
+  post "/breeders/@id/start":
+    let (code, response) = handleBreederStart(request, @"id")
+    resp code, [(
+      key: "Content-Type",
       val: "application/json"
     ), (
       key: "Access-Control-Allow-Origin",

--- a/shared/tests/stubs/controller/breeder_start.py
+++ b/shared/tests/stubs/controller/breeder_start.py
@@ -1,17 +1,16 @@
 def main(request_data=None):
-    """Stub for breeder_delete - deletes a breeder"""
+    """Stub for breeder_start - starts/resumes a breeder"""
     breeder_id = request_data.get("breeder_id") if request_data else None
-    force = request_data.get("force", False) if request_data else False
 
     if not breeder_id:
         return {"result": "FAILURE", "error": "Missing breeder_id parameter"}
 
-    # Simulate deletion (always succeeds for stub)
+    # Simulate start (always succeeds for stub)
     return {
         "result": "SUCCESS",
         "data": {
             "breeder_id": breeder_id,
-            "delete_type": "force" if force else "graceful",
-            "workers_cancelled": 1 if force else 0
+            "status": "ACTIVE",
+            "workers_started": 3
         }
     }

--- a/shared/tests/stubs/controller/breeder_stop.py
+++ b/shared/tests/stubs/controller/breeder_stop.py
@@ -1,17 +1,15 @@
 def main(request_data=None):
-    """Stub for breeder_delete - deletes a breeder"""
+    """Stub for breeder_stop - stops a breeder's workers"""
     breeder_id = request_data.get("breeder_id") if request_data else None
-    force = request_data.get("force", False) if request_data else False
 
     if not breeder_id:
         return {"result": "FAILURE", "error": "Missing breeder_id parameter"}
 
-    # Simulate deletion (always succeeds for stub)
+    # Simulate stop (always succeeds for stub)
     return {
         "result": "SUCCESS",
         "data": {
             "breeder_id": breeder_id,
-            "delete_type": "force" if force else "graceful",
-            "workers_cancelled": 1 if force else 0
+            "shutdown_type": "graceful"
         }
     }


### PR DESCRIPTION
  - Add POST /breeders/{id}/stop endpoint for graceful worker shutdown
  - Add POST /breeders/{id}/start endpoint to resume stopped breeders
  - Add force query parameter support to DELETE /breeders/{id}
  - Update Windmill adapter with stopBreeder() and startBreeder() methods
  - Add handlers for stop/start operations with proper error handling
  - Update test stubs for stop/start/delete operations
  - Align with controller v0.25.0 API changes