### PR TITLE
Reapply "fix: use correct target UUIDs in CI tests matching stub data"

### DIFF
--- a/.github/workflows/godon-api-ci.yml
+++ b/.github/workflows/godon-api-ci.yml
@@ -365,14 +365,14 @@ jobs:
         docker run --rm --network godon-api-test_default \
           ${{ steps.cli-image.outputs.CLI_CONTAINER_IMAGE }} \
           --hostname=godon-api-test --port=9090 --insecure \
-          target show --id=550e8400-e29b-41d4-a716-446655440022
+          target show --id=550e8400-e29b-41d4-a716-446655440020
 
         # Test deleting a target
         echo "Testing delete target:"
         docker run --rm --network godon-api-test_default \
           ${{ steps.cli-image.outputs.CLI_CONTAINER_IMAGE }} \
           --hostname=godon-api-test --port=9090 --insecure \
-          target delete --id=550e8400-e29b-41d4-a716-446655440022
+          target delete --id=550e8400-e29b-41d4-a716-446655440020
 
         # Test target error scenarios
         echo "Testing target error scenarios..."


### PR DESCRIPTION
This reverts commit c3c63212fbf35c11000eca8137041da4beb01d6e.