### PR TITLE
feat: target schema rework - spec JSONB for type-specific fields

### DIFF
--- a/images/godon-api/openapi.yml
+++ b/images/godon-api/openapi.yml
@@ -541,18 +541,22 @@ paths:
                     - id: "550e8400-e29b-41d4-a716-446655440020"
                       name: "production-server-1"
                       targetType: "ssh"
-                      address: "10.0.5.53"
-                      username: "godon_robot"
-                      credentialName: "godon_ssh_key"
-                      description: "Production server for network optimization"
-                      allowsDowntime: false
+                      spec:
+                        address: "10.0.5.53"
+                        username: "godon_robot"
+                        credential_id: "550e8400-e29b-41d4-a716-446655440010"
+                        allows_downtime: false
+                      metadata:
+                        description: "Production server for network optimization"
                       createdAt: "2024-01-15T10:30:00Z"
                     - id: "6ba7b810-9dad-11d1-80b4-00c04fd430ca"
                       name: "staging-api"
                       targetType: "http"
-                      address: "https://staging.example.com"
-                      description: "Staging HTTP API"
-                      allowsDowntime: true
+                      spec:
+                        url: "https://staging.example.com"
+                        auth_type: "none"
+                      metadata:
+                        description: "Staging HTTP API"
                       createdAt: "2024-01-16T14:20:00Z"
         '500':
           $ref: '#/components/responses/InternalServerError'
@@ -578,19 +582,23 @@ paths:
                 value:
                   name: "production-server-1"
                   targetType: "ssh"
-                  address: "10.0.5.53"
-                  username: "godon_robot"
-                  credentialName: "godon_ssh_key"
-                  description: "Production server for network optimization"
-                  allowsDowntime: false
+                  spec:
+                    address: "10.0.5.53"
+                    username: "godon_robot"
+                    credential_id: "550e8400-e29b-41d4-a716-446655440010"
+                    allows_downtime: false
+                  metadata:
+                    description: "Production server for network optimization"
               httpTarget:
                 summary: HTTP target system
                 value:
                   name: "staging-api"
                   targetType: "http"
-                  address: "https://staging.example.com"
-                  description: "Staging HTTP API"
-                  allowsDowntime: true
+                  spec:
+                    url: "https://staging.example.com"
+                    auth_type: "none"
+                  metadata:
+                    description: "Staging HTTP API"
       responses:
         '201':
           description: Successfully created the target
@@ -605,11 +613,13 @@ paths:
                     id: "550e8400-e29b-41d4-a716-446655440020"
                     name: "production-server-1"
                     targetType: "ssh"
-                    address: "10.0.5.53"
-                    username: "godon_robot"
-                    credentialName: "godon_ssh_key"
-                    description: "Production server for network optimization"
-                    allowsDowntime: false
+                    spec:
+                      address: "10.0.5.53"
+                      username: "godon_robot"
+                      credential_id: "550e8400-e29b-41d4-a716-446655440010"
+                      allows_downtime: false
+                    metadata:
+                      description: "Production server for network optimization"
                     createdAt: "2024-01-15T10:30:00Z"
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -963,7 +973,7 @@ components:
         - id
         - name
         - targetType
-        - address
+        - spec
         - createdAt
       properties:
         id:
@@ -984,32 +994,21 @@ components:
           enum: ["ssh", "http"]
           description: Type of target system
           example: "ssh"
-        address:
-          type: string
-          description: Hostname or IP address (SSH) or base URL (HTTP) of the target system
-          example: "10.0.5.53"
-        username:
-          type: string
-          description: Login username for SSH targets
-          example: "godon_robot"
-        credentialId:
-          type: string
-          format: uuid
-          description: UUID of the credential to use for authentication
-          example: "550e8400-e29b-41d4-a716-446655440001"
-        credentialName:
-          type: string
-          description: Name of the credential to use for authentication
-          example: "godon_ssh_key"
-        description:
-          type: string
-          description: Human-readable description of the target's purpose
-          example: "Production server for network optimization"
-        allowsDowntime:
-          type: boolean
-          description: Whether the target can tolerate downtime during optimization
-          default: false
-          example: false
+        spec:
+          type: object
+          description: Type-specific configuration. SSH spec requires {address, username, credential_id, allows_downtime}. HTTP spec requires {url, auth_type}.
+          additionalProperties: true
+          example:
+            address: "10.0.5.53"
+            username: "godon_robot"
+            credential_id: "550e8400-e29b-41d4-a716-446655440001"
+            allows_downtime: false
+        metadata:
+          type: object
+          description: Optional metadata associated with the target
+          additionalProperties: true
+          example:
+            description: "Production server for network optimization"
         createdAt:
           type: string
           format: date-time
@@ -1028,7 +1027,7 @@ components:
       required:
         - name
         - targetType
-        - address
+        - spec
       properties:
         name:
           type: string
@@ -1042,32 +1041,19 @@ components:
           enum: ["ssh", "http"]
           description: Type of target system
           example: "ssh"
-        address:
-          type: string
-          description: Hostname or IP address (SSH) or base URL (HTTP)
-          example: "10.0.5.53"
-        username:
-          type: string
-          description: Login username (required for SSH targets)
-          example: "godon_robot"
-        credentialId:
-          type: string
-          format: uuid
-          description: UUID of the credential to use for authentication
-          example: "550e8400-e29b-41d4-a716-446655440001"
-        credentialName:
-          type: string
-          description: Name of the credential to use for authentication
-          example: "godon_ssh_key"
-        description:
-          type: string
-          description: Human-readable description of the target's purpose
-          example: "Production server for network optimization"
-        allowsDowntime:
-          type: boolean
-          description: Whether the target can tolerate downtime
-          default: false
-          example: false
+        spec:
+          type: object
+          description: Type-specific configuration. SSH spec requires {address, username, credential_id, allows_downtime}. HTTP spec requires {url, auth_type}.
+          additionalProperties: true
+          example:
+            address: "10.0.5.53"
+            username: "godon_robot"
+            credential_id: "550e8400-e29b-41d4-a716-446655440001"
+            allows_downtime: false
+        metadata:
+          type: object
+          description: Optional metadata associated with the target
+          additionalProperties: true
 
     TargetList:
       type: array

--- a/images/godon-api/src/handlers.rs
+++ b/images/godon-api/src/handlers.rs
@@ -466,11 +466,11 @@ pub async fn create_target(
         ));
     }
 
-    if payload.address.trim().is_empty() {
+    if payload.spec.as_object().map(|o| o.is_empty()).unwrap_or(true) {
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
-                "Invalid address: address cannot be empty",
+                "Invalid spec: spec must be a non-empty object",
                 "BAD_REQUEST"
             ))
         ));
@@ -479,12 +479,8 @@ pub async fn create_target(
     let target_data = json!({
         "name": payload.name,
         "targetType": payload.target_type,
-        "address": payload.address,
-        "username": payload.username.as_deref().unwrap_or(""),
-        "credentialId": payload.credential_id.as_deref().unwrap_or(""),
-        "credentialName": payload.credential_name.as_deref().unwrap_or(""),
-        "description": payload.description.as_deref().unwrap_or(""),
-        "allowsDowntime": payload.allows_downtime.unwrap_or(false),
+        "spec": payload.spec,
+        "metadata": payload.metadata,
     });
 
     let client = get_client()?;

--- a/images/godon-api/src/types.rs
+++ b/images/godon-api/src/types.rs
@@ -64,15 +64,9 @@ pub struct Target {
     pub name: String,
     #[serde(rename = "targetType")]
     pub target_type: String,
-    pub address: String,
-    pub username: Option<String>,
-    #[serde(rename = "credentialId", skip_serializing_if = "Option::is_none")]
-    pub credential_id: Option<String>,
-    #[serde(rename = "credentialName", skip_serializing_if = "Option::is_none")]
-    pub credential_name: Option<String>,
-    pub description: Option<String>,
-    #[serde(rename = "allowsDowntime", skip_serializing_if = "Option::is_none")]
-    pub allows_downtime: Option<bool>,
+    pub spec: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
     #[serde(rename = "createdAt")]
     pub created_at: String,
     #[serde(rename = "lastUsedAt", skip_serializing_if = "Option::is_none")]
@@ -84,15 +78,9 @@ pub struct TargetCreate {
     pub name: String,
     #[serde(rename = "targetType")]
     pub target_type: String,
-    pub address: String,
-    pub username: Option<String>,
-    #[serde(rename = "credentialId", skip_serializing_if = "Option::is_none")]
-    pub credential_id: Option<String>,
-    #[serde(rename = "credentialName", skip_serializing_if = "Option::is_none")]
-    pub credential_name: Option<String>,
-    pub description: Option<String>,
-    #[serde(rename = "allowsDowntime", skip_serializing_if = "Option::is_none")]
-    pub allows_downtime: Option<bool>,
+    pub spec: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/images/godon-mcp/src/tools.rs
+++ b/images/godon-mcp/src/tools.rs
@@ -155,14 +155,10 @@ impl ToolRegistry {
                     "properties": {
                         "name": { "type": "string", "description": "Unique name for this target" },
                         "target_type": { "type": "string", "enum": ["ssh", "http"], "description": "Type of target system" },
-                        "address": { "type": "string", "description": "Hostname/IP (SSH) or base URL (HTTP)" },
-                        "username": { "type": "string", "description": "Login username (SSH targets)" },
-                        "credential_id": { "type": "string", "description": "UUID of credential to use for authentication" },
-                        "credential_name": { "type": "string", "description": "Name of credential to use for authentication" },
-                        "description": { "type": "string", "description": "Human-readable description" },
-                        "allows_downtime": { "type": "boolean", "description": "Whether target can tolerate downtime" }
+                        "spec": { "type": "object", "description": "Type-specific config. SSH: {address, username, credential_id, allows_downtime}. HTTP: {url, auth_type}" },
+                        "metadata": { "type": "object", "description": "Optional metadata for the target" }
                     },
-                    "required": ["name", "target_type", "address"],
+                    "required": ["name", "target_type", "spec"],
                     "additionalProperties": false
                 }),
             },

--- a/shared/tests/stubs/controller/target_create.py
+++ b/shared/tests/stubs/controller/target_create.py
@@ -18,9 +18,9 @@ def main(request_data=None):
             "error": f"Invalid targetType. Must be one of: {valid_types}"
         }
 
-    address = request_data.get("address")
-    if not address:
-        return {"result": "FAILURE", "error": "Missing required fields: address"}
+    spec = request_data.get("spec")
+    if not spec:
+        return {"result": "FAILURE", "error": "Missing required fields: spec"}
 
     return {
         "result": "SUCCESS",
@@ -28,12 +28,8 @@ def main(request_data=None):
             "id": "550e8400-e29b-41d4-a716-446655440021",
             "name": name,
             "targetType": target_type,
-            "address": address,
-            "username": request_data.get("username"),
-            "credentialId": request_data.get("credentialId"),
-            "credentialName": request_data.get("credentialName"),
-            "description": request_data.get("description", ""),
-            "allowsDowntime": request_data.get("allowsDowntime", False),
+            "spec": spec,
+            "metadata": request_data.get("metadata"),
             "createdAt": "2024-01-01T00:00:00Z",
             "lastUsedAt": None
         }

--- a/shared/tests/stubs/controller/target_get.py
+++ b/shared/tests/stubs/controller/target_get.py
@@ -13,12 +13,15 @@ def main(request_data=None):
             "id": "550e8400-e29b-41d4-a716-446655440020",
             "name": "test-server-1",
             "targetType": "ssh",
-            "address": "10.0.5.53",
-            "username": "godon_robot",
-            "credentialId": "550e8400-e29b-41d4-a716-446655440010",
-            "credentialName": "test-credential",
-            "description": "Test SSH server",
-            "allowsDowntime": False,
+            "spec": {
+                "address": "10.0.5.53",
+                "username": "godon_robot",
+                "credential_id": "550e8400-e29b-41d4-a716-446655440010",
+                "allows_downtime": False
+            },
+            "metadata": {
+                "description": "Test SSH server"
+            },
             "createdAt": "2024-01-01T00:00:00Z",
             "lastUsedAt": None
         },
@@ -26,12 +29,13 @@ def main(request_data=None):
             "id": "550e8400-e29b-41d4-a716-446655440021",
             "name": "test-api",
             "targetType": "http",
-            "address": "https://api.test.example.com",
-            "username": None,
-            "credentialId": None,
-            "credentialName": None,
-            "description": "Test HTTP API",
-            "allowsDowntime": True,
+            "spec": {
+                "url": "https://api.test.example.com",
+                "auth_type": "none"
+            },
+            "metadata": {
+                "description": "Test HTTP API"
+            },
             "createdAt": "2024-01-01T00:00:00Z",
             "lastUsedAt": None
         }

--- a/shared/tests/stubs/controller/targets_get.py
+++ b/shared/tests/stubs/controller/targets_get.py
@@ -7,12 +7,15 @@ def main(request_data=None):
                 "id": "550e8400-e29b-41d4-a716-446655440020",
                 "name": "test-server-1",
                 "targetType": "ssh",
-                "address": "10.0.5.53",
-                "username": "godon_robot",
-                "credentialId": "550e8400-e29b-41d4-a716-446655440010",
-                "credentialName": "test-credential",
-                "description": "Test SSH server",
-                "allowsDowntime": False,
+                "spec": {
+                    "address": "10.0.5.53",
+                    "username": "godon_robot",
+                    "credential_id": "550e8400-e29b-41d4-a716-446655440010",
+                    "allows_downtime": False
+                },
+                "metadata": {
+                    "description": "Test SSH server"
+                },
                 "createdAt": "2024-01-01T00:00:00Z",
                 "lastUsedAt": None
             },
@@ -20,12 +23,13 @@ def main(request_data=None):
                 "id": "550e8400-e29b-41d4-a716-446655440021",
                 "name": "test-api",
                 "targetType": "http",
-                "address": "https://api.test.example.com",
-                "username": None,
-                "credentialId": None,
-                "credentialName": None,
-                "description": "Test HTTP API",
-                "allowsDowntime": True,
+                "spec": {
+                    "url": "https://api.test.example.com",
+                    "auth_type": "none"
+                },
+                "metadata": {
+                    "description": "Test HTTP API"
+                },
                 "createdAt": "2024-01-01T00:00:00Z",
                 "lastUsedAt": None
             }

--- a/shared/tests/stubs/test-data/target-invalid-type.yaml
+++ b/shared/tests/stubs/test-data/target-invalid-type.yaml
@@ -1,3 +1,4 @@
 name: "test"
 targetType: "invalid_type"
-address: "10.0.5.53"
+spec:
+  address: "10.0.5.53"


### PR DESCRIPTION
- API spec: Target/TargetCreate schemas use spec + metadata
- Rust types: Target/TargetCreate structs use serde_json::Value for spec
- Handlers: validate spec is present, pass through to controller
- MCP: updated target_create tool schema
- Test stubs: updated for spec format