### PR TITLE
fix: align SSH spec - ssh_key_variable_path, allows_downtime to metad…

### DIFF
--- a/.github/workflows/godon-api-ci.yml
+++ b/.github/workflows/godon-api-ci.yml
@@ -344,9 +344,11 @@ jobs:
         echo "Creating test target..."
         echo 'name: "test-web-server"' > target-config.yaml
         echo 'targetType: "ssh"' >> target-config.yaml
-        echo 'address: "192.168.1.100"' >> target-config.yaml
-        echo 'username: "deploy"' >> target-config.yaml
-        echo 'description: "Test web server for CI"' >> target-config.yaml
+        echo 'spec:' >> target-config.yaml
+        echo '  address: "192.168.1.100"' >> target-config.yaml
+        echo '  username: "deploy"' >> target-config.yaml
+        echo 'metadata:' >> target-config.yaml
+        echo '  description: "Test web server for CI"' >> target-config.yaml
 
         docker run --rm --network godon-api-test_default \
           -v "$(pwd)/target-config.yaml:/target-config.yaml:ro" \

--- a/images/godon-api/openapi.yml
+++ b/images/godon-api/openapi.yml
@@ -544,10 +544,10 @@ paths:
                       spec:
                         address: "10.0.5.53"
                         username: "godon_robot"
-                        credential_id: "550e8400-e29b-41d4-a716-446655440010"
-                        allows_downtime: false
+                        ssh_key_variable_path: "f/vars/prod_ssh_key"
                       metadata:
                         description: "Production server for network optimization"
+                        allows_downtime: false
                       createdAt: "2024-01-15T10:30:00Z"
                     - id: "6ba7b810-9dad-11d1-80b4-00c04fd430ca"
                       name: "staging-api"
@@ -585,10 +585,10 @@ paths:
                   spec:
                     address: "10.0.5.53"
                     username: "godon_robot"
-                    credential_id: "550e8400-e29b-41d4-a716-446655440010"
-                    allows_downtime: false
+                    ssh_key_variable_path: "f/vars/prod_ssh_key"
                   metadata:
                     description: "Production server for network optimization"
+                    allows_downtime: false
               httpTarget:
                 summary: HTTP target system
                 value:
@@ -616,10 +616,10 @@ paths:
                     spec:
                       address: "10.0.5.53"
                       username: "godon_robot"
-                      credential_id: "550e8400-e29b-41d4-a716-446655440010"
-                      allows_downtime: false
+                      ssh_key_variable_path: "f/vars/prod_ssh_key"
                     metadata:
                       description: "Production server for network optimization"
+                      allows_downtime: false
                     createdAt: "2024-01-15T10:30:00Z"
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -996,19 +996,19 @@ components:
           example: "ssh"
         spec:
           type: object
-          description: Type-specific configuration. SSH spec requires {address, username, credential_id, allows_downtime}. HTTP spec requires {url, auth_type}.
+          description: "Type-specific configuration. SSH spec: {address, username, ssh_key_variable_path}. HTTP spec: {url, auth_type}."
           additionalProperties: true
           example:
             address: "10.0.5.53"
             username: "godon_robot"
-            credential_id: "550e8400-e29b-41d4-a716-446655440001"
-            allows_downtime: false
+            ssh_key_variable_path: "f/vars/prod_ssh_key"
         metadata:
           type: object
           description: Optional metadata associated with the target
           additionalProperties: true
           example:
             description: "Production server for network optimization"
+            allows_downtime: false
         createdAt:
           type: string
           format: date-time
@@ -1043,17 +1043,18 @@ components:
           example: "ssh"
         spec:
           type: object
-          description: Type-specific configuration. SSH spec requires {address, username, credential_id, allows_downtime}. HTTP spec requires {url, auth_type}.
+          description: "Type-specific configuration. SSH spec: {address, username, ssh_key_variable_path}. HTTP spec: {url, auth_type}."
           additionalProperties: true
           example:
             address: "10.0.5.53"
             username: "godon_robot"
-            credential_id: "550e8400-e29b-41d4-a716-446655440001"
-            allows_downtime: false
+            ssh_key_variable_path: "f/vars/prod_ssh_key"
         metadata:
           type: object
           description: Optional metadata associated with the target
           additionalProperties: true
+          example:
+            allows_downtime: false
 
     TargetList:
       type: array

--- a/images/godon-mcp/src/tools.rs
+++ b/images/godon-mcp/src/tools.rs
@@ -155,7 +155,7 @@ impl ToolRegistry {
                     "properties": {
                         "name": { "type": "string", "description": "Unique name for this target" },
                         "target_type": { "type": "string", "enum": ["ssh", "http"], "description": "Type of target system" },
-                        "spec": { "type": "object", "description": "Type-specific config. SSH: {address, username, credential_id, allows_downtime}. HTTP: {url, auth_type}" },
+                        "spec": { "type": "object", "description": "Type-specific config. SSH: {address, username, ssh_key_variable_path}. HTTP: {url, auth_type}" },
                         "metadata": { "type": "object", "description": "Optional metadata for the target" }
                     },
                     "required": ["name", "target_type", "spec"],


### PR DESCRIPTION
…ata, fix CI target creation

- OpenAPI spec examples use ssh_key_variable_path instead of credential_id
- allows_downtime moved from spec to metadata
- CI target creation uses spec JSONB format
- MCP tool description updated