### PR TITLE
feat: implement PUT /breeders/{id} update endpoint

### DIFF
--- a/.github/workflows/godon-api-ci.yml
+++ b/.github/workflows/godon-api-ci.yml
@@ -195,23 +195,26 @@ jobs:
 
         # Test updating a breeder
         echo "Testing update breeder:"
-        # Fetch example config for update test
         curl -s https://raw.githubusercontent.com/godon-dev/godon/refs/heads/master/examples/network.yml -o update-config.yaml
 
-        # Modify the config slightly to verify CLI reads it
         sed -i 's/parallel: 1/parallel: 2/' update-config.yaml
 
         echo "Update config file contents:"
         cat update-config.yaml
 
-        # Test breeder update - should return NOT_IMPLEMENTED
-        echo "Testing update breeder (should return NOT_IMPLEMENTED):"
+        echo "Testing update breeder:"
         docker run --rm --network godon-api-test_default \
           -v "$(pwd)/update-config.yaml:/update-config.yaml:ro" \
           ${{ steps.cli-image.outputs.CLI_CONTAINER_IMAGE }} \
           --hostname=godon-api-test --port=9090 --insecure \
-          breeder update --file=/update-config.yaml \
-          || echo "✅ Update correctly returned NOT_IMPLEMENTED as expected"
+          breeder update --id=550e8400-e29b-41d4-a716-446655440000 --file=/update-config.yaml
+
+        echo "Testing update breeder with force flag:"
+        docker run --rm --network godon-api-test_default \
+          -v "$(pwd)/update-config.yaml:/update-config.yaml:ro" \
+          ${{ steps.cli-image.outputs.CLI_CONTAINER_IMAGE }} \
+          --hostname=godon-api-test --port=9090 --insecure \
+          breeder update --id=550e8400-e29b-41d4-a716-446655440000 --file=/update-config.yaml --force
 
         # Test deleting a breeder (safe mode without workers)
         echo "Testing delete breeder (safe mode):"

--- a/images/godon-api/openapi.yml
+++ b/images/godon-api/openapi.yml
@@ -155,20 +155,33 @@ paths:
       description: Updates the configuration of an existing breeder
       requestBody:
         required: true
-        description: Updated breeder configuration
+        description: New breeder configuration. Trial data is preserved unless the config is incompatible.
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/BreederUpdate'
             examples:
               update:
-                summary: Updated breeder configuration
+                summary: Update breeder config
                 value:
-                  name: "updated-genetic-optimizer"
-                  description: "Updated optimizer configuration"
                   config:
-                    setting1: "new_value1"
-                    setting2: 200
+                    breeder:
+                      type: "linux_performance"
+                    objectives:
+                      - name: "latency"
+                        goal: "MINIMIZE"
+              force_update:
+                summary: Force update with incompatible config (clears trial history)
+                value:
+                  config:
+                    breeder:
+                      type: "linux_performance"
+                    objectives:
+                      - name: "latency"
+                        goal: "MINIMIZE"
+                      - name: "throughput"
+                        goal: "MAXIMIZE"
+                  force: true
 
       responses:
         '200':
@@ -177,23 +190,37 @@ paths:
             application/json:
               schema:
                 type: object
-                required:
-                  - id
-                  - updated
                 properties:
-                  id:
+                  result:
                     type: string
-                    format: uuid
-                    description: The ID of the updated breeder
-                  updated:
-                    type: boolean
-                    description: Confirmation that the breeder was updated
+                  data:
+                    type: object
+                    properties:
+                      breeder_id:
+                        type: string
+                        format: uuid
+                      name:
+                        type: string
+                      status:
+                        type: string
+                      workers_started:
+                        type: integer
+                      trials_cleared:
+                        type: boolean
+                      config_history_entries:
+                        type: integer
               examples:
                 updated:
                   summary: Update confirmation
                   value:
-                    id: "550e8400-e29b-41d4-a716-446655440000"
-                    updated: true
+                    result: "SUCCESS"
+                    data:
+                      breeder_id: "550e8400-e29b-41d4-a716-446655440000"
+                      name: "my-breeder"
+                      status: "active"
+                      workers_started: 2
+                      trials_cleared: false
+                      config_history_entries: 1
         '400':
           $ref: '#/components/responses/BadRequest'
         '404':
@@ -825,20 +852,14 @@ components:
         - description
         - config
       properties:
-        name:
-          type: string
-          minLength: 1
-          maxLength: 255
-          description: Human-readable name for the breeder
-          example: "updated-genetic-optimizer"
-        description:
-          type: string
-          description: Description of the breeder updates
-          example: "Updated optimizer configuration"
         config:
           type: object
-          description: Updated configuration object for the breeder
+          description: New breeder configuration (replaces existing config entirely)
           additionalProperties: true
+        force:
+          type: boolean
+          default: false
+          description: If true, clear trial history when config is incompatible with existing trial data (e.g. changed parameter or objective count)
 
     BreederList:
       type: array

--- a/images/godon-api/src/handlers.rs
+++ b/images/godon-api/src/handlers.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use serde_json::json;
 
 use crate::config::Config;
-use crate::types::{Breeder, BreederCreate, BreederSummary, Credential, CredentialCreate, DeleteResponse, ErrorResponse, Target, TargetCreate};
+use crate::types::{Breeder, BreederCreate, BreederUpdate, BreederSummary, Credential, CredentialCreate, DeleteResponse, ErrorResponse, Target, TargetCreate};
 use crate::windmill_adapter::WindmillClient;
 
 static BUILD_VERSION: &str = match option_env!("BUILD_VERSION") {
@@ -126,14 +126,49 @@ pub async fn get_breeder(
     ))?
 }
 
-pub async fn update_breeder() -> (StatusCode, Json<ErrorResponse>) {
-    (
-        StatusCode::NOT_IMPLEMENTED,
-        Json(ErrorResponse::new(
-            "Update breeder functionality not implemented",
-            "NOT_IMPLEMENTED"
-        ))
-    )
+pub async fn update_breeder(
+    State(_config): State<Config>,
+    Path(id): Path<String>,
+    Json(payload): Json<BreederUpdate>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    if !UUID_REGEX.is_match(&id) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::with_details(
+                "Invalid UUID format",
+                "BAD_REQUEST",
+                json!({"uuid": id})
+            ))
+        ));
+    }
+
+    if payload.config.as_object().map(|o| o.is_empty()).unwrap_or(true) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "Invalid config: config must be a non-empty object",
+                "BAD_REQUEST"
+            ))
+        ));
+    }
+
+    let client = get_client()?;
+    let force = payload.force.unwrap_or(false);
+
+    tokio::task::spawn_blocking(move || {
+        client.update_breeder(&id, payload.config, force)
+            .map(Json)
+            .map_err(|e| (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    format!("Failed to update breeder: {}", e),
+                    "INTERNAL_SERVER_ERROR"
+                ))
+            ))
+    }).await.map_err(|e| (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new(format!("Task join error: {}", e), "INTERNAL_SERVER_ERROR"))
+    ))?
 }
 
 #[derive(Debug, Deserialize)]

--- a/images/godon-api/src/types.rs
+++ b/images/godon-api/src/types.rs
@@ -27,9 +27,9 @@ pub struct BreederCreate {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BreederUpdate {
-    pub name: String,
-    pub description: String,
     pub config: serde_json::Value,
+    #[serde(default)]
+    pub force: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/images/godon-api/src/windmill_adapter.rs
+++ b/images/godon-api/src/windmill_adapter.rs
@@ -165,6 +165,16 @@ impl WindmillClient {
         Ok(Self::unwrap_data(response))
     }
 
+    pub fn update_breeder(&self, breeder_id: &str, config: serde_json::Value, force: bool) -> Result<serde_json::Value> {
+        let mut request_data = json!({ "breeder_id": breeder_id, "config": config });
+        if force {
+            request_data["force"] = json!(force);
+        }
+        let args = json!({ "request_data": request_data });
+        let response = self.run_script("breeder_update", args)?;
+        Ok(Self::unwrap_data(response))
+    }
+
     pub fn start_breeder(&self, breeder_id: &str) -> Result<serde_json::Value> {
         let args = json!({ "request_data": { "breeder_id": breeder_id } });
         let response = self.run_script("breeder_start", args)?;

--- a/shared/tests/stubs/controller/breeder_update.py
+++ b/shared/tests/stubs/controller/breeder_update.py
@@ -1,0 +1,23 @@
+def main(request_data=None):
+    if not request_data:
+        return {"result": "FAILURE", "error": "Missing request data"}
+
+    breeder_id = request_data.get("breeder_id")
+    if not breeder_id:
+        return {"result": "FAILURE", "error": "Missing breeder_id"}
+
+    config = request_data.get("config")
+    if not config:
+        return {"result": "FAILURE", "error": "Missing config"}
+
+    return {
+        "result": "SUCCESS",
+        "data": {
+            "breeder_id": breeder_id,
+            "name": "test-breeder",
+            "status": "active",
+            "workers_started": 1,
+            "trials_cleared": request_data.get("force", False),
+            "config_history_entries": 1
+        }
+    }


### PR DESCRIPTION
Accepts new breeder config with optional force flag. Validates config, calls controller script which checks trial compatibility and restarts workers with preserved trial data.