### PR TITLE
feat: add watermark detection endpoint with multi-method correlation

### DIFF
--- a/images/godon-observer/Cargo.toml
+++ b/images/godon-observer/Cargo.toml
@@ -17,3 +17,4 @@ log = "0.4"
 env_logger = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+fastrand = "2.0"

--- a/images/godon-observer/src/main.rs
+++ b/images/godon-observer/src/main.rs
@@ -191,6 +191,19 @@ async fn handle_request(req: Request<Body>, state: Arc<ObserverState>) -> Result
         };
     }
 
+    // /api/watermark-detection/<sender_id>/<receiver_id>
+    if path_parts.len() == 4 && path_parts[0] == "api" && path_parts[1] == "watermark-detection" {
+        let sender_id = path_parts[2].to_string();
+        let receiver_id = path_parts[3].to_string();
+        return match state.optuna.detect_watermark_coupling(&sender_id, &receiver_id).await {
+            Ok(result) => Ok(json_response(StatusCode::OK, &serde_json::to_string(&result).unwrap_or_default())),
+            Err(e) => {
+                error!("Watermark detection error: {}", e);
+                Ok(json_response(StatusCode::INTERNAL_SERVER_ERROR, &format!("{{\"error\": \"{}\"}}", e)))
+            }
+        };
+    }
+
     // /api/breeders — list all breeders with trial summaries
     if path_parts.len() == 2 && path_parts[0] == "api" && path_parts[1] == "breeders" {
         let url = format!("{}/breeders", state.api_url);

--- a/images/godon-observer/src/optuna_reader.rs
+++ b/images/godon-observer/src/optuna_reader.rs
@@ -371,12 +371,12 @@ impl OptunaReader {
             }));
         }
 
-        let wm_start = wm_timestamps.first().unwrap_or(&"");
-        let wm_end = wm_timestamps.last().unwrap_or(&"");
-        let rcv_start = &receiver_quality.first().unwrap().0;
-        let rcv_end = &receiver_quality.last().unwrap().0;
-        let overlap_start = if wm_start > rcv_start { wm_start } else { rcv_start };
-        let overlap_end = if wm_end < rcv_end { wm_end } else { rcv_end };
+        let wm_start = wm_timestamps.first().copied().unwrap_or("");
+        let wm_end = wm_timestamps.last().copied().unwrap_or("");
+        let rcv_start = receiver_quality.first().map(|(ts, _)| ts.as_str()).unwrap_or("");
+        let rcv_end = receiver_quality.last().map(|(ts, _)| ts.as_str()).unwrap_or("");
+        let overlap_start = if wm_start.cmp(rcv_start).is_gt() { wm_start } else { rcv_start };
+        let overlap_end = if wm_end.cmp(rcv_end).is_lt() { wm_end } else { rcv_end };
 
         if overlap_start >= overlap_end {
             return Ok(serde_json::json!({
@@ -387,12 +387,15 @@ impl OptunaReader {
             }));
         }
 
-        let aligned_signal: Vec<f64> = wm_trials.iter()
-            .filter(|t| t.datetime_start.as_deref().unwrap_or("") >= overlap_start
-                      && t.datetime_start.as_deref().unwrap_or("") <= overlap_end)
-            .enumerate()
-            .map(|(i, _)| wm_signal.get(i).copied().unwrap_or(0.0))
-            .collect();
+        let mut aligned_signal: Vec<f64> = Vec::new();
+        for (i, t) in wm_trials.iter().enumerate() {
+            let ts = t.datetime_start.as_deref().unwrap_or("");
+            if ts >= overlap_start && ts <= overlap_end {
+                if let Some(&v) = wm_signal.get(i) {
+                    aligned_signal.push(v);
+                }
+            }
+        }
 
         let aligned_quality: Vec<f64> = receiver_quality.iter()
             .filter(|(ts, _)| ts.as_str() >= overlap_start && ts.as_str() <= overlap_end)

--- a/images/godon-observer/src/optuna_reader.rs
+++ b/images/godon-observer/src/optuna_reader.rs
@@ -269,6 +269,197 @@ impl OptunaReader {
         }
     }
 
+    pub async fn detect_watermark_coupling(
+        &self,
+        sender_id: &str,
+        receiver_id: &str,
+    ) -> Result<serde_json::Value, Error> {
+        let sender_study = format!("{}_study", sender_id);
+        let receiver_study = format!("{}_study", receiver_id);
+
+        let sender_trials = self.get_trials(sender_id, &sender_study, 0, 10000).await?;
+        let receiver_trials = self.get_trials(receiver_id, &receiver_study, 0, 10000).await?;
+
+        let wm_trials: Vec<&TrialRecord> = sender_trials.iter()
+            .filter(|t| t.user_attrs.contains_key("watermark"))
+            .collect();
+
+        if wm_trials.is_empty() {
+            return Ok(serde_json::json!({
+                "detected": false,
+                "reason": "no watermark trials found",
+                "sender_id": sender_id,
+                "receiver_id": receiver_id,
+            }));
+        }
+
+        let wm_meta = &wm_trials[0].user_attrs["watermark"];
+        let wm_type = wm_meta.get("type").and_then(|v| v.as_str()).unwrap_or("unknown");
+
+        let wm_signal: Vec<f64> = match wm_type {
+            "on_off" => {
+                let period = wm_meta.get("period").and_then(|v| as_f64(v)).unwrap_or(10.0) as usize;
+                wm_trials.iter().map(|t| {
+                    let idx = t.user_attrs.get("watermark_trial_idx")
+                        .and_then(|v| as_f64(v)).unwrap_or(0.0) as usize;
+                    if (idx / period) % 2 == 0 { 1.0 } else { 0.0 }
+                }).collect()
+            },
+            "sinusoidal" => {
+                let period = wm_meta.get("period").and_then(|v| as_f64(v)).unwrap_or(20.0);
+                let amplitude = wm_meta.get("amplitude").and_then(|v| as_f64(v)).unwrap_or(0.1);
+                wm_trials.iter().map(|t| {
+                    let idx = t.user_attrs.get("watermark_trial_idx")
+                        .and_then(|v| as_f64(v)).unwrap_or(0.0);
+                    amplitude * (2.0 * std::f64::consts::PI * idx / period).sin()
+                }).collect()
+            },
+            "step" => {
+                let period = wm_meta.get("period").and_then(|v| as_f64(v)).unwrap_or(10.0) as usize;
+                let step_fraction = wm_meta.get("step_fraction").and_then(|v| as_f64(v)).unwrap_or(0.2);
+                wm_trials.iter().map(|t| {
+                    let idx = t.user_attrs.get("watermark_trial_idx")
+                        .and_then(|v| as_f64(v)).unwrap_or(0.0) as usize;
+                    if (idx / period) % 2 == 0 { step_fraction } else { 0.0 }
+                }).collect()
+            },
+            "multi_frequency" => {
+                let base_period = wm_meta.get("base_period").and_then(|v| as_f64(v)).unwrap_or(20.0);
+                let amplitude = wm_meta.get("amplitude").and_then(|v| as_f64(v)).unwrap_or(0.1);
+                wm_trials.iter().map(|t| {
+                    let idx = t.user_attrs.get("watermark_trial_idx")
+                        .and_then(|v| as_f64(v)).unwrap_or(0.0);
+                    amplitude * (2.0 * std::f64::consts::PI * idx / base_period).sin()
+                }).collect()
+            },
+            _ => {
+                return Ok(serde_json::json!({
+                    "detected": false,
+                    "reason": format!("unsupported watermark type: {}", wm_type),
+                }));
+            }
+        };
+
+        if wm_signal.len() < 4 {
+            return Ok(serde_json::json!({
+                "detected": false,
+                "reason": "too few watermark trials",
+                "watermark_trials": wm_signal.len(),
+            }));
+        }
+
+        let receiver_quality: Vec<(String, f64)> = receiver_trials.iter()
+            .filter(|t| t.state == "COMPLETE")
+            .filter(|t| t.datetime_start.is_some())
+            .filter(|t| t.values.first().map_or(false, |v| v.is_some() && v.is_finite()))
+            .filter_map(|t| {
+                let ts = t.datetime_start.clone()?;
+                let val = t.values.first().and_then(|v| *v)?;
+                Some((ts, val))
+            })
+            .collect();
+
+        let wm_timestamps: Vec<&str> = wm_trials.iter()
+            .filter_map(|t| t.datetime_start.as_deref())
+            .collect();
+
+        if receiver_quality.len() < 4 {
+            return Ok(serde_json::json!({
+                "detected": false,
+                "reason": "too few receiver quality values",
+                "receiver_trials": receiver_quality.len(),
+            }));
+        }
+
+        let wm_start = wm_timestamps.first().unwrap_or(&"");
+        let wm_end = wm_timestamps.last().unwrap_or(&"");
+        let rcv_start = &receiver_quality.first().unwrap().0;
+        let rcv_end = &receiver_quality.last().unwrap().0;
+        let overlap_start = if wm_start > rcv_start { wm_start } else { rcv_start };
+        let overlap_end = if wm_end < rcv_end { wm_end } else { rcv_end };
+
+        if overlap_start >= overlap_end {
+            return Ok(serde_json::json!({
+                "detected": false,
+                "reason": "no temporal overlap between watermark and receiver trials",
+                "watermark_range": [wm_start, wm_end],
+                "receiver_range": [rcv_start, rcv_end],
+            }));
+        }
+
+        let aligned_signal: Vec<f64> = wm_trials.iter()
+            .filter(|t| t.datetime_start.as_deref().unwrap_or("") >= overlap_start
+                      && t.datetime_start.as_deref().unwrap_or("") <= overlap_end)
+            .enumerate()
+            .map(|(i, _)| wm_signal.get(i).copied().unwrap_or(0.0))
+            .collect();
+
+        let aligned_quality: Vec<f64> = receiver_quality.iter()
+            .filter(|(ts, _)| ts.as_str() >= overlap_start && ts.as_str() <= overlap_end)
+            .map(|(_, v)| *v)
+            .collect();
+
+        let n_align = aligned_signal.len().min(aligned_quality.len());
+        if n_align < 4 {
+            return Ok(serde_json::json!({
+                "detected": false,
+                "reason": "too few temporally aligned trials",
+                "aligned_trials": n_align,
+            }));
+        }
+
+        let sig = &aligned_signal[..n_align];
+        let qual = &aligned_quality[..n_align];
+
+        let max_lag = (n_align / 3).max(1).min(20);
+        let (pearson, pearson_lag) = best_cross_correlation(sig, qual, max_lag);
+        let (spearman, spearman_lag) = best_spearman_lag(sig, qual, max_lag);
+        let matched = matched_filter(sig, qual);
+
+        let best_corr = pearson.abs().max(spearman.abs()).max(matched.abs());
+        let best_method = if best_corr == matched.abs() { "matched_filter" }
+                          else if best_corr == spearman.abs() { "spearman" }
+                          else { "pearson" };
+        let best_lag = if best_method == "spearman" { spearman_lag } else { pearson_lag };
+
+        let n_perm = 5000usize;
+        let mut rng = fastrand::Rng::new();
+        let mut exceed_count = 0usize;
+        for _ in 0..n_perm {
+            let mut shuffled: Vec<f64> = qual.to_vec();
+            shuffle_vec(&mut shuffled, &mut rng);
+            let perm_pearson = best_cross_correlation(sig, &shuffled, max_lag).0;
+            let perm_spearman = best_spearman_lag(sig, &shuffled, max_lag).0;
+            let perm_matched = matched_filter(sig, &shuffled);
+            let perm_best = perm_pearson.abs().max(perm_spearman.abs()).max(perm_matched.abs());
+            if perm_best >= best_corr {
+                exceed_count += 1;
+            }
+        }
+        let p_value = (exceed_count + 1) as f64 / (n_perm + 1) as f64;
+
+        let detected = p_value < 0.05 && best_corr > 0.1;
+
+        Ok(serde_json::json!({
+            "detected": detected,
+            "sender_id": sender_id,
+            "receiver_id": receiver_id,
+            "watermark_type": wm_type,
+            "watermark_trials": wm_signal.len(),
+            "receiver_trials": receiver_quality.len(),
+            "aligned_trials": n_align,
+            "temporal_overlap": [overlap_start, overlap_end],
+            "pearson": {"correlation": round4(pearson), "lag": pearson_lag},
+            "spearman": {"correlation": round4(spearman), "lag": spearman_lag},
+            "matched_filter": round4(matched),
+            "best_method": best_method,
+            "best_correlation": round4(best_corr),
+            "best_lag": best_lag,
+            "p_value": round4(p_value),
+            "permutations": n_perm,
+        }))
+    }
+
     pub async fn get_choreography_status(&self) -> Result<serde_json::Value, Error> {
         let client = self.connect("archive_db").await?;
 
@@ -341,5 +532,130 @@ impl OptunaReader {
             "choreographies": choreographies,
             "active_breeders": active_breeders,
         }))
+    }
+}
+
+fn as_f64(v: &serde_json::Value) -> Option<f64> {
+    v.as_f64().or_else(|| v.as_i64().map(|i| i as f64))
+}
+
+fn round4(v: f64) -> f64 {
+    (v * 10000.0).round() / 10000.0
+}
+
+fn pearson_correlation(x: &[f64], y: &[f64]) -> f64 {
+    let n = x.len().min(y.len());
+    if n < 2 { return 0.0; }
+    let mx = x.iter().sum::<f64>() / n as f64;
+    let my = y.iter().sum::<f64>() / n as f64;
+    let mut cov = 0.0_f64;
+    let mut vx = 0.0_f64;
+    let mut vy = 0.0_f64;
+    for i in 0..n {
+        let dx = x[i] - mx;
+        let dy = y[i] - my;
+        cov += dx * dy;
+        vx += dx * dx;
+        vy += dy * dy;
+    }
+    let denom = vx.sqrt() * vy.sqrt();
+    if denom == 0.0 { return 0.0; }
+    cov / denom
+}
+
+fn best_cross_correlation(signal: &[f64], quality: &[f64], max_lag: usize) -> (f64, i32) {
+    let n = signal.len().min(quality.len());
+    if n < 2 { return (0.0, 0); }
+    let mut best_corr = 0.0_f64;
+    let mut best_lag = 0_i32;
+    for lag in 0..=max_lag {
+        if lag >= n { break; }
+        let s_end = n - lag;
+        let corr = pearson_correlation(&signal[..s_end], &quality[lag..lag + s_end]);
+        if corr.abs() > best_corr.abs() {
+            best_corr = corr;
+            best_lag = lag as i32;
+        }
+        if lag > 0 && n - lag >= 2 {
+            let corr_rev = pearson_correlation(&signal[lag..n], &quality[..n - lag]);
+            if corr_rev.abs() > best_corr.abs() {
+                best_corr = corr_rev;
+                best_lag = -(lag as i32);
+            }
+        }
+    }
+    (best_corr, best_lag)
+}
+
+fn rank_data(data: &[f64]) -> Vec<f64> {
+    let mut indexed: Vec<(usize, f64)> = data.iter().enumerate().map(|(i, &v)| (i, v)).collect();
+    indexed.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+    let mut ranks = vec![0.0_f64; data.len()];
+    let mut i = 0;
+    while i < indexed.len() {
+        let mut j = i + 1;
+        while j < indexed.len() && indexed[j].1 == indexed[i].1 {
+            j += 1;
+        }
+        let avg_rank = (i + j - 1) as f64 / 2.0 + 1.0;
+        for k in i..j {
+            ranks[indexed[k].0] = avg_rank;
+        }
+        i = j;
+    }
+    ranks
+}
+
+fn spearman_correlation(x: &[f64], y: &[f64]) -> f64 {
+    let n = x.len().min(y.len());
+    if n < 2 { return 0.0; }
+    let rx = rank_data(&x[..n]);
+    let ry = rank_data(&y[..n]);
+    pearson_correlation(&rx, &ry)
+}
+
+fn best_spearman_lag(signal: &[f64], quality: &[f64], max_lag: usize) -> (f64, i32) {
+    let n = signal.len().min(quality.len());
+    if n < 2 { return (0.0, 0); }
+    let mut best_corr = 0.0_f64;
+    let mut best_lag = 0_i32;
+    for lag in 0..=max_lag {
+        if lag >= n { break; }
+        let s_end = n - lag;
+        let corr = spearman_correlation(&signal[..s_end], &quality[lag..lag + s_end]);
+        if corr.abs() > best_corr.abs() {
+            best_corr = corr;
+            best_lag = lag as i32;
+        }
+        if lag > 0 && n - lag >= 2 {
+            let corr_rev = spearman_correlation(&signal[lag..n], &quality[..n - lag]);
+            if corr_rev.abs() > best_corr.abs() {
+                best_corr = corr_rev;
+                best_lag = -(lag as i32);
+            }
+        }
+    }
+    (best_corr, best_lag)
+}
+
+fn matched_filter(template: &[f64], signal: &[f64]) -> f64 {
+    let n = template.len().min(signal.len());
+    if n < 2 { return 0.0; }
+    let t_mean = template[..n].iter().sum::<f64>() / n as f64;
+    let s_mean = signal[..n].iter().sum::<f64>() / n as f64;
+    let t_norm: f64 = template[..n].iter().map(|v| (v - t_mean).powi(2)).sum::<f64>().sqrt();
+    let s_norm: f64 = signal[..n].iter().map(|v| (v - s_mean).powi(2)).sum::<f64>().sqrt();
+    if t_norm == 0.0 || s_norm == 0.0 { return 0.0; }
+    let mut sum = 0.0_f64;
+    for i in 0..n {
+        sum += (template[i] - t_mean) * (signal[i] - s_mean);
+    }
+    sum / (t_norm * s_norm)
+}
+
+fn shuffle_vec(v: &mut [f64], rng: &mut fastrand::Rng) {
+    for i in (1..v.len()).rev() {
+        let j = rng.usize(..=i);
+        v.swap(i, j);
     }
 }

--- a/images/godon-observer/src/optuna_reader.rs
+++ b/images/godon-observer/src/optuna_reader.rs
@@ -351,7 +351,7 @@ impl OptunaReader {
         let receiver_quality: Vec<(String, f64)> = receiver_trials.iter()
             .filter(|t| t.state == "COMPLETE")
             .filter(|t| t.datetime_start.is_some())
-            .filter(|t| t.values.first().map_or(false, |v| v.is_some() && v.is_finite()))
+            .filter(|t| t.values.first().map_or(false, |v| v.is_some_and(|f| f.is_finite())))
             .filter_map(|t| {
                 let ts = t.datetime_start.clone()?;
                 let val = t.values.first().and_then(|v| *v)?;


### PR DESCRIPTION
New /api/watermark-detection/<sender>/<receiver> endpoint that:
- Reconstructs known watermark pattern from sender trial metadata
- Aligns sender and receiver trials by temporal overlap
- Runs three correlation methods: Pearson (linear), Spearman (rank/nonlinear), matched filter (optimal known-signal detector)
- Tests multiple lag offsets to find best alignment
- Permutation test (5000 shuffles) for statistical significance
- Returns best method, correlation, lag, and p-value