### PR TITLE
fix: parse watermark user attr from JSON string

### DIFF
--- a/images/godon-observer/src/optuna_reader.rs
+++ b/images/godon-observer/src/optuna_reader.rs
@@ -293,7 +293,12 @@ impl OptunaReader {
             }));
         }
 
-        let wm_meta = &wm_trials[0].user_attrs["watermark"];
+        let wm_raw = &wm_trials[0].user_attrs["watermark"];
+        let wm_meta: serde_json::Value = if wm_raw.is_string() {
+            serde_json::from_str(wm_raw.as_str().unwrap_or("{}")).unwrap_or(serde_json::json!({}))
+        } else {
+            wm_raw.clone()
+        };
         let wm_type = wm_meta.get("type").and_then(|v| v.as_str()).unwrap_or("unknown");
 
         let wm_signal: Vec<f64> = match wm_type {


### PR DESCRIPTION
Breeder stores watermark metadata as json.dumps(), producing a string. The Rust endpoint expected a JSON object. Parse string attrs before accessing fields.